### PR TITLE
Add comprehensive match analysis endpoint

### DIFF
--- a/backend/src/controllers/matchesController.js
+++ b/backend/src/controllers/matchesController.js
@@ -761,6 +761,27 @@ const matchesController = {
   },
 
   /**
+   * Get comprehensive analysis including historical stats
+   */
+  getComprehensiveAnalysis: async (req, res) => {
+    try {
+      const { id: matchId } = req.params;
+      logger.info(`Getting comprehensive analysis for match ${matchId}`, { service: 'matches' });
+
+      const data = await require('../services/comprehensiveMatchAnalysisService').getComprehensiveMatchAnalysis(matchId);
+
+      if (!data) {
+        return res.status(404).json({ success: false, error: 'Match not found' });
+      }
+
+      res.json({ success: true, result: data, source: 'FootyStats', timestamp: new Date().toISOString() });
+    } catch (error) {
+      logger.error(`Error getting comprehensive analysis for ${req.params.id}:`, error);
+      res.status(500).json({ success: false, error: 'Failed to get comprehensive analysis', message: error.message });
+    }
+  },
+
+  /**
    * Get complete match details
    */
   getCompleteMatchDetails: async (req, res) => {

--- a/backend/src/routes/api.js
+++ b/backend/src/routes/api.js
@@ -79,6 +79,9 @@ router.get('/matches/:id/odds', matchesController.getMatchOdds);
 // Comprehensive match analysis
 router.get('/matches/:id/analysis', matchesController.getMatchAnalysis);
 
+// New comprehensive analysis with historical data
+router.get('/matches/:id/comprehensive-analysis', matchesController.getComprehensiveAnalysis);
+
 // Complete match details with all analytics
 router.get('/matches/:id/complete', matchesController.getCompleteMatchDetails);
 

--- a/backend/src/services/comprehensiveMatchAnalysisService.js
+++ b/backend/src/services/comprehensiveMatchAnalysisService.js
@@ -1,0 +1,104 @@
+const footyStatsApi = require('./footyStatsApiService');
+const logger = require('../utils/logger');
+
+/**
+ * Compute over/under statistics for an array of matches
+ * @param {Array} matches Array of match objects
+ * @param {Function} extractor Function to extract numeric value from a match
+ * @param {number[]} thresholds Threshold values
+ * @returns {Object} Stats keyed by threshold
+ */
+function computeThresholdStats(matches, extractor, thresholds) {
+  const valid = matches.map(extractor).filter(v => typeof v === 'number' && !isNaN(v));
+  const total = valid.length;
+  const result = {};
+  thresholds.forEach(th => {
+    const count = valid.filter(v => v > th).length;
+    result[th] = {
+      over: count,
+      under: total - count,
+      overPct: total ? Number(((count / total) * 100).toFixed(1)) : 0,
+      underPct: total ? Number((((total - count) / total) * 100).toFixed(1)) : 0
+    };
+  });
+  return { total, thresholds: result };
+}
+
+/**
+ * Helper to fetch a team's matches by venue and limit
+ */
+async function fetchTeamMatches(teamId, venue, limit, seasonId) {
+  try {
+    const params = {
+      team_id: teamId,
+      venue,
+      max_per_page: limit,
+      order: 'date_desc'
+    };
+    if (seasonId) params.season_id = seasonId;
+    const res = await footyStatsApi.cachedApiRequest('/league-matches', params, `${teamId}-${venue}-${limit}-${seasonId}`, footyStatsApi.CACHE_TTL.TEAM_STATS);
+    return Array.isArray(res?.data) ? res.data.slice(0, limit) : [];
+  } catch (err) {
+    logger.error(`Failed to fetch matches for team ${teamId}`, { error: err.message });
+    return [];
+  }
+}
+
+/**
+ * Calculate goal, card and corner stats for given matches
+ */
+function aggregateMatchStats(matches) {
+  const goalExtractor = m => parseInt(m.totalGoalCount ?? (m.homeGoalCount || 0) + (m.awayGoalCount || 0));
+  const cardExtractor = m => {
+    const hY = parseInt(m.team_a_yellow_cards || 0);
+    const hR = parseInt(m.team_a_red_cards || 0);
+    const aY = parseInt(m.team_b_yellow_cards || 0);
+    const aR = parseInt(m.team_b_red_cards || 0);
+    return hY + hR + aY + aR;
+  };
+  const cornerExtractor = m => parseInt(m.totalCornerCount ?? (m.team_a_corners || 0) + (m.team_b_corners || 0));
+
+  return {
+    goals: computeThresholdStats(matches, goalExtractor, [0.5,1.5,2.5,3.5,4.5,5.5]),
+    cards: computeThresholdStats(matches, cardExtractor, [0.5,1.5,2.5,3.5,4.5,5.5]),
+    corners: computeThresholdStats(matches, cornerExtractor, [6.5,7.5,8.5,9.5,10.5,11.5,12.5,13.5])
+  };
+}
+
+/**
+ * Get comprehensive analysis for a match
+ */
+async function getComprehensiveMatchAnalysis(matchId) {
+  const match = await footyStatsApi.getMatchDetails(matchId);
+  if (!match) return null;
+  const seasonId = match.season || match.season_id || null;
+  const homeId = match.homeTeam?.id;
+  const awayId = match.awayTeam?.id;
+
+  const [home5, home10, away5, away10, referee, standings] = await Promise.all([
+    fetchTeamMatches(homeId, 'home', 5, seasonId),
+    fetchTeamMatches(homeId, 'home', 10, seasonId),
+    fetchTeamMatches(awayId, 'away', 5, seasonId),
+    fetchTeamMatches(awayId, 'away', 10, seasonId),
+    match.referee?.id ? footyStatsApi.getRefereeStats(match.referee.id) : null,
+    seasonId ? footyStatsApi.getLeagueStandings(seasonId) : null
+  ]);
+
+  return {
+    match,
+    league: standings,
+    referee: referee,
+    homeTeam: {
+      last5Home: aggregateMatchStats(home5),
+      last10Home: aggregateMatchStats(home10)
+    },
+    awayTeam: {
+      last5Away: aggregateMatchStats(away5),
+      last10Away: aggregateMatchStats(away10)
+    }
+  };
+}
+
+module.exports = {
+  getComprehensiveMatchAnalysis
+};

--- a/backend/src/services/footyStatsApiService.js
+++ b/backend/src/services/footyStatsApiService.js
@@ -295,6 +295,35 @@ const getTeamLastXStats = async (teamId) => {
 };
 
 /**
+ * Get recent matches for a team filtered by venue
+ * @param {number|string} teamId
+ * @param {'home'|'away'} venue
+ * @param {number} limit
+ * @param {number|null} seasonId
+ */
+const getTeamVenueMatches = async (teamId, venue, limit = 5, seasonId = null) => {
+  try {
+    const params = {
+      team_id: teamId,
+      venue,
+      max_per_page: limit,
+      order: 'date_desc'
+    };
+    if (seasonId) params.season_id = seasonId;
+
+    const cacheKey = `${CACHE_KEYS.TEAM_STATS}-${teamId}-${venue}-${limit}-${seasonId}`;
+    const data = await cachedApiRequest('/league-matches', params, cacheKey, CACHE_TTL.TEAM_STATS);
+    return Array.isArray(data?.data) ? data.data.slice(0, limit) : [];
+  } catch (error) {
+    logger.error(`Error fetching FootyStats venue matches for ${teamId}:`, {
+      service: 'footystats-api',
+      error: error.message
+    });
+    return [];
+  }
+};
+
+/**
  * Get league players for player analysis
  */
 const getLeaguePlayers = async (seasonId, page = 1) => {
@@ -886,6 +915,7 @@ module.exports = {
   // Team analysis  
   getTeamStats,
   getTeamLastXStats,
+  getTeamVenueMatches,
   getTeamCornerStats,
   getTeamCardStats,
   getTeamBTTSStats,

--- a/tests/backend/api/matches/comprehensive.test.js
+++ b/tests/backend/api/matches/comprehensive.test.js
@@ -1,0 +1,18 @@
+const request = require('supertest');
+const app = require('../../../../src/app');
+
+describe('Comprehensive Match Analysis Endpoint', () => {
+  test('GET /api/matches/:id/comprehensive-analysis returns structured data', async () => {
+    // Use a mock ID; service will likely return 404 if not found
+    const response = await request(app)
+      .get('/api/matches/1/comprehensive-analysis')
+      .expect('Content-Type', /json/);
+
+    // Accept 200 or 404 depending on dataset availability
+    expect([200,404]).toContain(response.status);
+    if (response.status === 200) {
+      expect(response.body).toHaveProperty('success', true);
+      expect(response.body).toHaveProperty('result.match');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- implement `comprehensiveMatchAnalysisService` to aggregate historical stats
- expose new route `/api/matches/:id/comprehensive-analysis`
- support venue-based match fetch via `getTeamVenueMatches`
- add controller logic for comprehensive analysis
- include integration test skeleton for new endpoint

## Testing
- `npm run test:backend` *(fails: `jest: Permission denied`)*

------
https://chatgpt.com/codex/tasks/task_e_684867b1f5548332a8822942ab8093ec